### PR TITLE
Add helper and docs for resolving failed system admin Prisma migration

### DIFF
--- a/docs/troubleshooting/prisma-migrations.md
+++ b/docs/troubleshooting/prisma-migrations.md
@@ -1,0 +1,35 @@
+# Prisma migration troubleshooting
+
+When running `prisma migrate deploy` against a shared database, Prisma will refuse to apply new migrations if any previous migration is still marked as failed.  This protects the history in the `_prisma_migrations` table, but it also means that a partially-applied migration must be explicitly resolved before development can continue.
+
+## "system_admin_role" failure (P3009)
+
+If you see output similar to:
+
+```
+Prisma schema loaded from prisma/schema.prisma
+Datasource "db": PostgreSQL database "neondb", schema "public" at "ep-noisy-paper-a1bxuoqo.ap-southeast-1.aws.neon.tech"
+Error: P3009
+migrate found failed migrations in the target database, new migrations will not be applied.
+The `20250501000000_system_admin_role` migration started at ... failed
+```
+
+resolve the failure by marking the broken migration as rolled back and then rerunning the deploy:
+
+```bash
+# mark the failed migration as rolled back so Prisma will continue
+npm run migrate:resolve:system-admin
+
+# re-apply migrations
+npm run migrate:deploy
+```
+
+The `migrate:resolve:system-admin` helper simply calls:
+
+```bash
+prisma migrate resolve --rolled-back "20250501000000_system_admin_role"
+```
+
+This tells Prisma that the migration should be treated as rolled back.  You can then create a follow-up migration (if needed) or allow the subsequent migrations in this repository to apply normally.
+
+> **Note:** Prisma never deletes the failed migration record from `_prisma_migrations`.  It is safe to keep the entry as "rolled back" so long as a replacement migration has been checked in (as is the case in this repository).

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "predev:api": "npm run migrate:deploy",
     "migrate": "prisma migrate deploy",
     "migrate:deploy": "prisma migrate deploy",
+    "migrate:resolve:system-admin": "prisma migrate resolve --rolled-back \"20250501000000_system_admin_role\"",
     "seed:csv": "tsx scripts/loadCsv.ts",
     "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js --runInBand",
     "lint": "eslint .",


### PR DESCRIPTION
## Summary
- add an npm script that marks the failed `20250501000000_system_admin_role` migration as rolled back
- document the steps to resolve the Prisma P3009 error when that migration blocks deploys

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68daa5b024c8832e90c437a8fd39daca